### PR TITLE
Fix listening to presence channel broadcast

### DIFF
--- a/js/component/LaravelEcho.js
+++ b/js/component/LaravelEcho.js
@@ -35,9 +35,15 @@ export default function () {
                             store.emit(event, e)
                         })
                     } else if (channel_type == 'presence') {
-                        Echo.join(channel)[event_name](e => {
-                            store.emit(event, e)
-                        })
+                        if (Echo.join(channel)[event_name] === undefined) {
+                            Echo.join(channel).listen(event_name, e => {
+                                store.emit(event, e)
+                            })
+                        } else {
+                            Echo.join(channel)[event_name](e => {
+                                store.emit(event, e)
+                            })
+                        }
                     } else if (channel_type == 'notification') {
                         Echo.private(channel).notification(notification => {
                             store.emit(event, notification)


### PR DESCRIPTION
Hi,

This code wasn't working because Livewire try to call the `Echo.join(channel)[here/joining/leaving]()` but we can also listen to PresenceChannel with `.listen()` (https://laravel.com/docs/8.x/broadcasting#broadcasting-to-presence-channels).
```
    protected $listeners = ['echo-presence:orders,OrderShipped' => 'notifyNewOrder'];
```

I fixed it by looking if the method exists on the `PresenceChannel` JS object (here, joining, leaving) but it may be preferable to do a clearer check with `if (event_name === 'here' && event_name === 'joining'…)`. I can modify the pull request if you want.